### PR TITLE
implement a shutdown protocol

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        node: [18.17.1, 20.x]
+        node: [18.x, 20.x]
         exclude:
           - platform: windows-latest
             node: 20.x
@@ -38,10 +38,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js 18.17.1
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v3
       with:
-        node-version: 18.17.1
+        node-version: 18.x
     - run: npm ci
     - run: npm run build -if-present
     - run: npm run c8

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,24 @@ export function createSQLiteThread(options?: SQLiteOptions): Promise<SQLite.Prom
       }
     });
   }).then((p) => {
+    // The original SQLite WASM Promiser interface is enriched with a close
+    // method that can properly dispose of a thread
     p.close = () => {
-      worker.terminate();
+      debug['threads']('Sending destroy to SQL Worker');
+      return new Promise<void>((resolve, reject) => {
+        const tmout = setTimeout(() => {
+          worker.terminate();
+          reject('Timeout when destroying worker');
+        }, VFSHTTP.defaultOptions.timeout);
+        worker.onmessage = ({ data }) => {
+          debug['threads']('Received response from SQL Worker being destroyed', data);
+          if (data.type === 'ack') {
+            clearTimeout(tmout);
+            resolve();
+          }
+        };
+        worker.postMessage({ type: 'destroy' });
+      });
     };
     return p;
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ export function createSQLiteThread(options?: SQLiteOptions): Promise<SQLite.Prom
       debug['threads']('Sending destroy to SQL Worker');
       return new Promise<void>((resolve, reject) => {
         const tmout = setTimeout(() => {
+          // .terminate() should be used only as a last resort since there seems to
+          // be an issue in recent Node.js versions when using WASM in a worker_thread
           worker.terminate();
           reject('Timeout when destroying worker');
         }, VFSHTTP.defaultOptions.timeout);

--- a/src/vfs-http-types.ts
+++ b/src/vfs-http-types.ts
@@ -83,7 +83,7 @@ const debugOptions = (typeof SQLITE_DEBUG !== 'undefined' && SQLITE_DEBUG) ||
   (typeof process !== 'undefined' && typeof process?.env?.SQLITE_DEBUG !== 'undefined' && process.env.SQLITE_DEBUG) ||
   '';
 
-export const debugSys = ['threads', 'vfs', 'cache', 'http'] as const;
+export const debugSys = ['threads', 'io', 'vfs', 'cache', 'http'] as const;
 export const debug = {} as Record<typeof debugSys[number], (...args: unknown[]) => void>;
 for (const d of debugSys) {
   debug[d] = debugOptions.includes(d) ?

--- a/src/vfs-http-worker.ts
+++ b/src/vfs-http-worker.ts
@@ -237,7 +237,7 @@ const backendAsyncMethods:
   }
 };
 
-async function workMessage(this: Consumer, { data }: { data: VFSHTTP.Message }) {
+async function workMessage(this: Consumer, { data }: { data: VFSHTTP.Message; }) {
   debug['io']('Received new work message', this, data);
   let r;
   try {

--- a/src/vfs-http-worker.ts
+++ b/src/vfs-http-worker.ts
@@ -1,4 +1,4 @@
-// This is the entry point for an HTTP backend thread
+// This is the entry point the shared HTTP backend thread
 // It can serve multiple SQLite worker threads
 
 import LRUCache from 'lru-cache';
@@ -238,12 +238,12 @@ const backendAsyncMethods:
 };
 
 async function workMessage(this: Consumer, { data }: { data: VFSHTTP.Message }) {
-  debug['threads']('Received new work message', this, data);
+  debug['io']('Received new work message', this, data);
   let r;
   try {
     r = await backendAsyncMethods[data.msg](data, this);
 
-    debug['threads']('operation successful', this, r);
+    debug['io']('operation successful', this, r);
     Atomics.store(this.lock, 0, r);
   } catch (e) {
     console.error(e);

--- a/src/vfs-http.ts
+++ b/src/vfs-http.ts
@@ -1,6 +1,7 @@
 // This is the VFS layer for the shared backend
-// It run in each SQLite worker thread that uses it
-// and it is fully synchronous
+// It runs in each SQLite worker thread and exposes a synchronous interface
+// the the SQLite WASM
+// It uses vfs-http-worker of which there is a single instance
 
 import * as VFSHTTP from './vfs-http-types.js';
 import { debug } from './vfs-http-types.js';

--- a/src/vfs-http.ts
+++ b/src/vfs-http.ts
@@ -64,7 +64,7 @@ export function installHttpVfs(
     if (r === 'timed-out') {
       console.error('Backend timeout', r, lock, msg);
       return -1;
-    } 
+    }
     return rc;
   };
 

--- a/src/vfs-sync-http.ts
+++ b/src/vfs-sync-http.ts
@@ -1,6 +1,6 @@
 // This is the ersatz HTTP backend
 // It does not require SharedArrayBuffer and does not share its cache
-// It runs in the SQLite worker thread
+// It runs in each SQLite worker thread
 
 import LRUCache from 'lru-cache';
 import { ntoh16 } from './endianness.js';

--- a/test/http-pool.test.ts
+++ b/test/http-pool.test.ts
@@ -75,15 +75,11 @@ for (const type of ['sync', 'shared'] as const) {
             done('beyond the event horizon');
           })
           .catch((e) => {
-            pool.close();
             assert.include(e.result.message, 'sqlite3 result code 14: unable to open database file');
-            done();
+            pool.close().then(done);
           })
-          .catch((e) => {
-            // Obviously a major malfunction, the above code should never throw
-            done(e);
-          })
-        );
+        )
+        .catch(done);
     });
   });
 }

--- a/test/vfs-http.test.ts
+++ b/test/vfs-http.test.ts
@@ -296,7 +296,7 @@ for (const back of Object.keys(backTests) as (keyof typeof backTests)[]) {
           .then(() => {
             assert.strictEqual(tiles, concurrentDb.length);
           })
-          .finally(() => 
+          .finally(() =>
             Promise.all(concurrentDb.map((dbq) => dbq.then((db) => db.close())))
           )
           .then(done)

--- a/test/vfs-http.test.ts
+++ b/test/vfs-http.test.ts
@@ -296,10 +296,10 @@ for (const back of Object.keys(backTests) as (keyof typeof backTests)[]) {
           .then(() => {
             assert.strictEqual(tiles, concurrentDb.length);
           })
-          .finally(() => {
-            Promise.all(concurrentDb.map((dbq) => dbq.then((db) => db.close())));
-            done();
-          })
+          .finally(() => 
+            Promise.all(concurrentDb.map((dbq) => dbq.then((db) => db.close())))
+          )
+          .then(done)
           .catch(done);
       });
     }


### PR DESCRIPTION
Avoid using `Worker.terminate()` since since there seems to be an issue in recent Node.js versions when using WASM in a `worker_thread` - it can cause an infinite loop in `node::FreeEnvironment`.

The problem is much more frequent since Node.js 18.18 on macOS and Windows but it seems present - albeit very rare - even on earlier versions and on Linux.

Fixes #65 