### PR TITLE
Support databases with a page size of 65536

### DIFF
--- a/src/vfs-http-worker.ts
+++ b/src/vfs-http-worker.ts
@@ -118,6 +118,11 @@ const backendAsyncMethods:
         return r;
       ntoh16(pageData);
       entry.pageSize = pageData[0];
+      if (entry.pageSize == 1) {
+        // From https://www.sqlite.org/fileformat2.html#database_header,
+        // a value of 1 represents a page size of 65536.
+        entry.pageSize = 65536;
+      }
       debug['vfs'](`page size is ${entry.pageSize}`);
       if (entry.pageSize != 1024) {
         // If the page size is not 1024 we can't keep this "page" in the cache

--- a/src/vfs-sync-http.ts
+++ b/src/vfs-sync-http.ts
@@ -96,6 +96,11 @@ export function installSyncHttpVfs(sqlite3: SQLite3, options?: VFSHTTP.Options) 
           return capi.SQLITE_IOERR;
         ntoh16(pageData);
         entry.pageSize = pageData[0];
+        if (entry.pageSize == 1) {
+          // From https://www.sqlite.org/fileformat2.html#database_header,
+          // a value of 1 represents a page size of 65536.
+          entry.pageSize = 65536;
+        }
         debug['vfs'](`page size is ${entry.pageSize}`);
         if (entry.pageSize != 1024) {
           // If the page size is not 1024 we can't keep this "page" in the cache


### PR DESCRIPTION
Currently, page sizes of 65536 fail to work as the library misinterprets it as having a page size of 1. This is because for databases with a page size of 65536, the pageSize field in the database is actually set to 1, see https://www.sqlite.org/fileformat2.html#database_header

This commit fixes that issue.